### PR TITLE
Fix deanonymizer call when output_format is provided

### DIFF
--- a/anonLLM/llm.py
+++ b/anonLLM/llm.py
@@ -28,7 +28,7 @@ class OpenaiLanguageModel:
         self.temperature = temperature
         openai.api_key = self.api_key
 
-    def generate(self, prompt: str, output_format: Optional[BaseModel] = None,
+    def generate(self, prompt: str, output_format: Optional[Type[BaseModel]] = None,
                  n_completions: int = 1, max_tokens: int = None):
         anonymized_prompt, mappings = (self.anonymizer.anonymize_data(prompt)
                                        if self.anonymize else (prompt, None))

--- a/tests/test_openai_language_model.py
+++ b/tests/test_openai_language_model.py
@@ -1,4 +1,7 @@
 import unittest
+
+from pydantic import BaseModel
+
 from anonLLM.llm import OpenaiLanguageModel
 from dotenv import load_dotenv
 
@@ -22,6 +25,18 @@ class TestOpenaiLanguageModel(unittest.TestCase):
         self.assertIsNotNone(response)
         self.assertNotEqual("", response.strip())
         self.assertIn("Alice Johnson", response)
+
+    def test_generate_with_model_output(self):
+        class Output(BaseModel):
+            person: str
+            city: str
+
+        prompt = 'Extract the requested  information from the following sentence: "John Hanson is visiting Rome."'
+        response = self.llm.generate(prompt, output_format=Output)
+        self.assertTrue(isinstance(response, Output))
+        self.assertIn("John Hanson", response.person)
+        self.assertIn("Rome", response.city)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_openai_language_model.py
+++ b/tests/test_openai_language_model.py
@@ -31,11 +31,35 @@ class TestOpenaiLanguageModel(unittest.TestCase):
             person: str
             city: str
 
-        prompt = 'Extract the requested  information from the following sentence: "John Hanson is visiting Rome."'
+        prompt = 'Extract the requested  information from the following sentence: "Alice Johnson is visiting Rome."'
         response = self.llm.generate(prompt, output_format=Output)
         self.assertTrue(isinstance(response, Output))
-        self.assertIn("John Hanson", response.person)
+        self.assertIn("Alice Johnson", response.person)
         self.assertIn("Rome", response.city)
+
+    def test_generate_n_completions(self):
+        prompt = (
+            "What is the user's favorite color in the following expression?"
+            "\nAlice Johnson's favorite color is blue"
+        )
+        responses = self.llm.generate(prompt, n_completions=2)
+        self.assertEqual(len(responses), 2)
+        for response in responses:
+            self.assertIsNotNone(response)
+            self.assertIn("blue", response.lower())
+
+    def test_generate_n_completions_with_model_output(self):
+        class Output(BaseModel):
+            person: str
+            city: str
+
+        prompt = 'Extract the requested  information from the following sentence: "Alice Johnson is visiting Rome."'
+        responses = self.llm.generate(prompt, output_format=Output, n_completions=2)
+        self.assertEqual(len(responses), 2)
+        for response in responses:
+            self.assertTrue(isinstance(response, Output))
+            self.assertIn("Alice Johnson", response.person)
+            self.assertIn("Rome", response.city)
 
 
 


### PR DESCRIPTION
Hello, cool project. I was testing it out and noticed the `output_format` functionality wasn't fully in-place, specifically in that since the data has been converted to a dictionary here https://github.com/fsndzomga/anonLLM/blob/26a38705656c0222ec11f72c56dc6047d007cb96/anonLLM/llm.py#L71 the later call to the deanonymizer fails when it tries to perform string operations.

I've added a fix for this, implemented the loading of the output into the provided pydantic model, and added test coverage for this and the `n_completions` logic. 

Please take a look and consider this change. 

```
tests/test_anonymizer.py::TestAnonymizer::test_anonymize_data PASSED                                       [ 16%]
tests/test_deanonymizer.py::TestDeanonymizer::test_deanonymize PASSED                                      [ 33%]
tests/test_openai_language_model.py::TestOpenaiLanguageModel::test_generate PASSED                         [ 50%]
tests/test_openai_language_model.py::TestOpenaiLanguageModel::test_generate_n_completions PASSED           [ 66%]
tests/test_openai_language_model.py::TestOpenaiLanguageModel::test_generate_n_completions_with_model_output PASSED [ 83%]
tests/test_openai_language_model.py::TestOpenaiLanguageModel::test_generate_with_model_output PASSED       [100%]

=============================================== 6 passed in 16.00s ===============================================
```